### PR TITLE
feat: handle dashboard loading and errors

### DIFF
--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { 
   Car, 
   DollarSign, 
@@ -12,96 +12,145 @@ import {
 } from 'lucide-react';
 import PieChart from '@/components/PieChart';
 
+// Données par défaut simulées pour le tableau de bord
+const weeklyDataDefault = {
+  'Du lun. 11 août - dim. 17 août 2025': {
+    gain: 400000,
+    recettes: 400000,
+    charges: 0,
+    reparations: 0
+  },
+  'Du lun. 4 août - dim. 10 août 2025': {
+    gain: 350000,
+    recettes: 380000,
+    charges: 30000,
+    reparations: 0
+  },
+  'Du lun. 28 juil - dim. 3 août 2025': {
+    gain: 320000,
+    recettes: 350000,
+    charges: 25000,
+    reparations: 5000
+  }
+};
+
+const vehiclesDataDefault = [
+  {
+    reference: 'EM20517-01',
+    achat: 8000000,
+    gain: 2428500,
+    reste: 5571500
+  },
+  {
+    reference: 'EM28431-01',
+    achat: 8000000,
+    gain: 1035000,
+    reste: 6965000
+  },
+  {
+    reference: 'EM13548-01',
+    achat: 6500000,
+    gain: 1850000,
+    reste: 4650000
+  }
+];
+
+const monthlyHistoryDefault = {
+  'Août': {
+    tousVehicules: {
+      gain: 1475000,
+      recettes: 1475000,
+      charges: 0,
+      reparations: 0
+    },
+    parVehicule: {
+      'EM20517-01': { gain: 242500, recettes: 242500, charges: 0, reparations: 0 },
+      'EM28431-01': { gain: 185000, recettes: 185000, charges: 0, reparations: 0 },
+      'EM13548-01': { gain: 463800, recettes: 537500, charges: 26000, reparations: 47700 }
+    }
+  },
+  'Juillet': {
+    tousVehicules: {
+      gain: 3035500,
+      recettes: 3530000,
+      charges: 404500,
+      reparations: 90000
+    },
+    parVehicule: {
+      'EM20517-01': { gain: 580000, recettes: 620000, charges: 35000, reparations: 5000 },
+      'EM28431-01': { gain: 420000, recettes: 450000, charges: 25000, reparations: 5000 },
+      'EM13548-01': { gain: 2035500, recettes: 2460000, charges: 344500, reparations: 80000 }
+    }
+  },
+  'Juin': {
+    tousVehicules: {
+      gain: 2850000,
+      recettes: 3200000,
+      charges: 280000,
+      reparations: 70000
+    },
+    parVehicule: {
+      'EM20517-01': { gain: 520000, recettes: 550000, charges: 25000, reparations: 5000 },
+      'EM28431-01': { gain: 380000, recettes: 400000, charges: 15000, reparations: 5000 },
+      'EM13548-01': { gain: 1950000, recettes: 2250000, charges: 240000, reparations: 60000 }
+    }
+  }
+};
+
+type DashboardData = {
+  weeklyData: typeof weeklyDataDefault;
+  vehiclesData: typeof vehiclesDataDefault;
+  monthlyHistory: typeof monthlyHistoryDefault;
+};
+
+function useDashboardData() {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        // Remplacer par un appel API réel si nécessaire
+        setData({
+          weeklyData: weeklyDataDefault,
+          vehiclesData: vehiclesDataDefault,
+          monthlyHistory: monthlyHistoryDefault,
+        });
+      } catch (e) {
+        setError(e);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    load();
+  }, []);
+
+  return { data, isLoading, error };
+}
+
 const Dashboard: React.FC = () => {
   const [selectedWeek, setSelectedWeek] = useState('Du lun. 11 août - dim. 17 août 2025');
   const [selectedMonth, setSelectedMonth] = useState('Août');
 
-  // Données par défaut - Semaines
-  const weeklyData = {
-    'Du lun. 11 août - dim. 17 août 2025': {
-      gain: 400000,
-      recettes: 400000,
-      charges: 0,
-      reparations: 0
-    },
-    'Du lun. 4 août - dim. 10 août 2025': {
-      gain: 350000,
-      recettes: 380000,
-      charges: 30000,
-      reparations: 0
-    },
-    'Du lun. 28 juil - dim. 3 août 2025': {
-      gain: 320000,
-      recettes: 350000,
-      charges: 25000,
-      reparations: 5000
-    }
-  };
+  const { data, isLoading, error } = useDashboardData();
 
-  // Données par défaut - Véhicules (Total cumulé)
-  const vehiclesData = [
-    {
-      reference: 'EM20517-01',
-      achat: 8000000,
-      gain: 2428500,
-      reste: 5571500
-    },
-    {
-      reference: 'EM28431-01',
-      achat: 8000000,
-      gain: 1035000,
-      reste: 6965000
-    },
-    {
-      reference: 'EM13548-01',
-      achat: 6500000,
-      gain: 1850000,
-      reste: 4650000
-    }
-  ];
+  if (isLoading) {
+    return <div className="p-6">Chargement…</div>;
+  }
 
-  // Données par défaut - Historique mensuel
-  const monthlyHistory = {
-    'Août': {
-      tousVehicules: {
-        gain: 1475000,
-        recettes: 1475000,
-        charges: 0,
-        reparations: 0
-      },
-      parVehicule: {
-        'EM20517-01': { gain: 242500, recettes: 242500, charges: 0, reparations: 0 },
-        'EM28431-01': { gain: 185000, recettes: 185000, charges: 0, reparations: 0 },
-        'EM13548-01': { gain: 463800, recettes: 537500, charges: 26000, reparations: 47700 }
-      }
-    },
-    'Juillet': {
-      tousVehicules: {
-        gain: 3035500,
-        recettes: 3530000,
-        charges: 404500,
-        reparations: 90000
-      },
-      parVehicule: {
-        'EM20517-01': { gain: 580000, recettes: 620000, charges: 35000, reparations: 5000 },
-        'EM28431-01': { gain: 420000, recettes: 450000, charges: 25000, reparations: 5000 },
-        'EM13548-01': { gain: 2035500, recettes: 2460000, charges: 344500, reparations: 80000 }
-      }
-    },
-    'Juin': {
-      tousVehicules: {
-        gain: 2850000,
-        recettes: 3200000,
-        charges: 280000,
-        reparations: 70000
-      },
-      parVehicule: {
-        'EM20517-01': { gain: 520000, recettes: 550000, charges: 25000, reparations: 5000 },
-        'EM28431-01': { gain: 380000, recettes: 400000, charges: 15000, reparations: 5000 },
-        'EM13548-01': { gain: 1950000, recettes: 2250000, charges: 240000, reparations: 60000 }
-      }
-    }
-  };
+  if (error || !data) {
+    return (
+      <div className="p-6 text-red-500">
+        Erreur: {(error as any)?.message || 'Une erreur est survenue'}
+      </div>
+    );
+  }
+
+  const weeklyData = data.weeklyData;
+  const vehiclesData = data.vehiclesData;
+  const monthlyHistory = data.monthlyHistory;
 
   const months = ['Août', 'Juillet', 'Juin', 'Mai', 'Avril', 'Mars', 'Février'];
   const weeks = Object.keys(weeklyData);
@@ -116,20 +165,20 @@ const Dashboard: React.FC = () => {
 
   // Données pour le graphique en secteurs
   const pieChartData = [
-    { 
-      label: 'Recettes', 
-      value: currentMonthData.tousVehicules.recettes, 
-      color: '#10B981' 
+    {
+      label: 'Recettes',
+      value: currentMonthData.tousVehicules.recettes,
+      color: '#10B981'
     },
-    { 
-      label: 'Charges', 
-      value: currentMonthData.tousVehicules.charges, 
-      color: '#3B82F6' 
+    {
+      label: 'Charges',
+      value: currentMonthData.tousVehicules.charges,
+      color: '#3B82F6'
     },
-    { 
-      label: 'Réparations', 
-      value: currentMonthData.tousVehicules.reparations, 
-      color: '#F59E0B' 
+    {
+      label: 'Réparations',
+      value: currentMonthData.tousVehicules.reparations,
+      color: '#F59E0B'
     }
   ];
 


### PR DESCRIPTION
## Summary
- add local dashboard data hook exposing loading and error states
- show loading indicator and error message before rendering dashboard content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any)


------
https://chatgpt.com/codex/tasks/task_e_68a07bd0c5508324ba8e0a3b1c262ce2