### PR TITLE
Centralize FCFA currency formatting utility

### DIFF
--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import {
   Receipt,
 } from 'lucide-react';
 import PieChart from '@/components/PieChart';
+import { formatCurrency, formatCurrencyFull } from '@/utils/format';
 
 const Dashboard: React.FC = () => {
   const [selectedWeek, setSelectedWeek] = useState('Du lun. 11 août - dim. 17 août 2025');
@@ -132,14 +133,6 @@ const Dashboard: React.FC = () => {
       color: '#F59E0B' 
     }
   ];
-
-  const formatCurrency = (amount: number) => {
-    return `${(amount / 1000).toLocaleString()} FCFA`;
-  };
-
-  const formatCurrencyFull = (amount: number) => {
-    return `${amount.toLocaleString()} FCFA`;
-  };
 
   const getPercentage = (value: number, total: number) => {
     if (total === 0) return 0;

--- a/src/features/dashboard/pages/DashboardHistory.tsx
+++ b/src/features/dashboard/pages/DashboardHistory.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 // ⚠️ si l'alias "@" n'est pas configuré, remplace par: "../../../core/api/client"
 import { get } from "@/core/api/client";
 import { PieChart, Pie, Tooltip, Legend, ResponsiveContainer, Cell } from "recharts";
+import { formatCurrencyFull } from "@/utils/format";
 
 // ---- Types API
 type Car = {
@@ -172,19 +173,19 @@ export default function DashboardHistory() {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div>
             <div className="opacity-70 text-sm">Gain</div>
-            <div className="text-xl font-semibold">{(total.gain || 0).toLocaleString()} FCFA</div>
+            <div className="text-xl font-semibold">{formatCurrencyFull(total.gain || 0)}</div>
           </div>
           <div>
             <div className="opacity-70 text-sm">Recettes</div>
-            <div className="text-xl font-semibold">{(total.recettes || 0).toLocaleString()} FCFA</div>
+            <div className="text-xl font-semibold">{formatCurrencyFull(total.recettes || 0)}</div>
           </div>
           <div>
             <div className="opacity-70 text-sm">Charges</div>
-            <div className="text-xl font-semibold">{(total.charges || 0).toLocaleString()} FCFA</div>
+            <div className="text-xl font-semibold">{formatCurrencyFull(total.charges || 0)}</div>
           </div>
           <div>
             <div className="opacity-70 text-sm">Réparations</div>
-            <div className="text-xl font-semibold">{(total.reparations || 0).toLocaleString()} FCFA</div>
+            <div className="text-xl font-semibold">{formatCurrencyFull(total.reparations || 0)}</div>
           </div>
         </div>
       </div>
@@ -204,14 +205,14 @@ export default function DashboardHistory() {
               <div className="text-orange-600 font-semibold mb-1">{label}</div>
               {b.prixAchat != null && (
                 <div className="text-sm">
-                  Achat <span className="font-semibold">{b.prixAchat.toLocaleString()} FCFA</span>
+                  Achat <span className="font-semibold">{formatCurrencyFull(b.prixAchat ?? 0)}</span>
                 </div>
               )}
               <div className="text-sm">
-                Gain <span className="font-semibold text-green-600">{b.gain.toLocaleString()} FCFA</span>
+                Gain <span className="font-semibold text-green-600">{formatCurrencyFull(b.gain)}</span>
               </div>
               <div className="text-sm">
-                Reste <span className="font-semibold text-red-600">{reste.toLocaleString()} FCFA</span>
+                Reste <span className="font-semibold text-red-600">{formatCurrencyFull(reste)}</span>
               </div>
               <div className="h-2 bg-gray-200 rounded mt-2 overflow-hidden">
                 <div className="h-full bg-green-500" style={{ width: `${ratio}%` }} />

--- a/src/features/operations/pages/OperationsPage.tsx
+++ b/src/features/operations/pages/OperationsPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useOperations, useDeleteOperation } from "../queries";
 import OperationForm from "../components/OperationForm";
+import { formatCurrencyFull } from "@/utils/format";
 
 const OperationsPage: React.FC = () => {
   const { data, isLoading, error } = useOperations({});
@@ -22,7 +23,7 @@ const OperationsPage: React.FC = () => {
             <li key={op.id ?? op.reference} className="flex items-center justify-between p-3 rounded-lg border">
               <div>
                 <div className="font-medium">{op.date} — {op.type}</div>
-                <div className="text-sm opacity-80">{op.amount?.toLocaleString()} FCFA</div>
+                <div className="text-sm opacity-80">{formatCurrencyFull(op.amount || 0)}</div>
               </div>
               {op.id && (
                 <button className="px-3 py-1 rounded border" onClick={() => del.mutate(op.id!)}>

--- a/src/features/recettes/pages/RecettesPage.tsx
+++ b/src/features/recettes/pages/RecettesPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useRecettes, useDeleteRecette } from "../queries";
 import RecetteForm from "../components/RecetteForm";
+import { formatCurrencyFull } from "@/utils/format";
 
 const RecettesPage: React.FC = () => {
   const { data, isLoading, error } = useRecettes({});
@@ -24,7 +25,7 @@ const RecettesPage: React.FC = () => {
             <li key={r.id} className="flex items-center justify-between p-3 rounded-lg border">
               <div>
                 <div className="font-medium">{r.date} — {r.carRef}</div>
-                <div className="text-sm opacity-80">{r.montant?.toLocaleString()} FCFA</div>
+                <div className="text-sm opacity-80">{formatCurrencyFull(r.montant || 0)}</div>
               </div>
               {r.id && (
                 <button className="btn btn-sm" onClick={() => del.mutate(r.id!)}>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,7 @@
+export const formatCurrency = (amount: number): string => {
+  return `${(amount / 1000).toLocaleString()} FCFA`;
+};
+
+export const formatCurrencyFull = (amount: number): string => {
+  return `${amount.toLocaleString()} FCFA`;
+};


### PR DESCRIPTION
## Summary
- add `formatCurrency` and `formatCurrencyFull` helpers
- refactor dashboard, history, operations and recettes pages to reuse new currency formatter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a08139b1148324b7e05323c9c84169