### PR TITLE
Add scrolling navigation for dashboard vehicle totals

### DIFF
--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { 
   Car, 
   DollarSign, 
@@ -23,8 +23,9 @@ const Dashboard: React.FC = () => {
   const [selectedMonth, setSelectedMonth] = useState('Août');
   const [weeks, setWeeks] = useState<WeekDto[]>([]);
   const [weeklyData, setWeeklyData] = useState<Record<string, WeeklyStat>>({});
-  const [vehicleIndex, setVehicleIndex] = useState(0);
-  const vehiclesPerPage = 3;
+  const vehicleListRef = useRef<HTMLDivElement>(null);
+  const [canPrevVehicle, setCanPrevVehicle] = useState(false);
+  const [canNextVehicle, setCanNextVehicle] = useState(false);
 
   useEffect(() => {
     const allWeeks = getWeeksOfYear(new Date().getFullYear());
@@ -63,18 +64,25 @@ const Dashboard: React.FC = () => {
   const { data: vehiclesData } = useDashboardVehicles();
   const { data: monthlyHistory } = useDashboardMonthly(selectedMonth);
 
-  const visibleVehicles =
-    vehiclesData?.slice(vehicleIndex, vehicleIndex + vehiclesPerPage) ?? [];
-  const canPrevVehicle = vehicleIndex > 0;
-  const canNextVehicle =
-    vehiclesData ? vehicleIndex + vehiclesPerPage < vehiclesData.length : false;
+  useEffect(() => {
+    const el = vehicleListRef.current;
+    if (!el) return;
+    const updateButtons = () => {
+      setCanPrevVehicle(el.scrollLeft > 0);
+      setCanNextVehicle(el.scrollLeft + el.clientWidth < el.scrollWidth);
+    };
+    updateButtons();
+    el.addEventListener('scroll', updateButtons);
+    return () => el.removeEventListener('scroll', updateButtons);
+  }, [vehiclesData]);
 
-  const navigateVehicles = (direction: 'prev' | 'next') => {
-    if (direction === 'prev' && canPrevVehicle) {
-      setVehicleIndex((i) => Math.max(0, i - vehiclesPerPage));
-    } else if (direction === 'next' && canNextVehicle) {
-      setVehicleIndex((i) => i + vehiclesPerPage);
-    }
+  const scrollVehicles = (direction: 'prev' | 'next') => {
+    const el = vehicleListRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth;
+    const left =
+      direction === 'next' ? el.scrollLeft + scrollAmount : el.scrollLeft - scrollAmount;
+    el.scrollTo({ left, behavior: 'smooth' });
   };
 
   const currentWeekData =
@@ -269,28 +277,26 @@ const Dashboard: React.FC = () => {
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-xl font-bold text-gray-800">Total cumulé</h2>
-          <div className="flex space-x-2">
-            <button
-              onClick={() => navigateVehicles('prev')}
-              disabled={!canPrevVehicle}
-              className="p-2 rounded-lg hover:bg-gray-100 disabled:opacity-50"
-            >
-              <ChevronLeft className="w-5 h-5 text-gray-600" />
-            </button>
-            <button
-              onClick={() => navigateVehicles('next')}
-              disabled={!canNextVehicle}
-              className="p-2 rounded-lg hover:bg-gray-100 disabled:opacity-50"
-            >
-              <ChevronRight className="w-5 h-5 text-gray-600" />
-            </button>
-          </div>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {visibleVehicles.map((vehicle) => (
-            <div key={vehicle.reference} className="border border-orange-200 rounded-xl p-4">
-              <h3 className="text-lg font-bold text-orange-600 mb-4">{vehicle.reference}</h3>
+        <div className="relative">
+          <button
+            onClick={() => scrollVehicles('prev')}
+            disabled={!canPrevVehicle}
+            className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-1/2 p-2 bg-white rounded-full shadow hover:bg-gray-100 disabled:opacity-50"
+          >
+            <ChevronLeft className="w-6 h-6 text-gray-600" />
+          </button>
+          <div
+            ref={vehicleListRef}
+            className="flex gap-6 overflow-x-auto no-scrollbar scroll-smooth py-1 px-4"
+          >
+            {vehiclesData?.map((vehicle) => (
+              <div
+                key={vehicle.reference}
+                className="min-w-[280px] border border-orange-200 rounded-xl p-4"
+              >
+                <h3 className="text-lg font-bold text-orange-600 mb-4">{vehicle.reference}</h3>
               
               <div className="space-y-3">
                 <div className="flex justify-between items-center">
@@ -321,8 +327,16 @@ const Dashboard: React.FC = () => {
                   {((vehicle.gain / vehicle.achat) * 100).toFixed(1)}% remboursé
                 </p>
               </div>
-            </div>
-          ))}
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={() => scrollVehicles('next')}
+            disabled={!canNextVehicle}
+            className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 p-2 bg-white rounded-full shadow hover:bg-gray-100 disabled:opacity-50"
+          >
+            <ChevronRight className="w-6 h-6 text-gray-600" />
+          </button>
         </div>
 
         {/* Résumé total */}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add horizontal scroll with next/previous controls for vehicle total section
- hide scrollbar with custom utility class

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f29fa4388324969aee6bde3f302d