### PR TITLE
Add weekly pagination for recettes list

### DIFF
--- a/src/core/utils/DateUtils.ts
+++ b/src/core/utils/DateUtils.ts
@@ -4,7 +4,7 @@ export const jours = ["Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendre
 
 export const mois = ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"] as const;
 
-const weeks = [] as WeekDto[];
+let weeks = [] as WeekDto[];
 
 export const toISODate = (dt: Date): string => dt.toLocaleDateString("en-CA");
 
@@ -117,6 +117,13 @@ export function getWeeksOfYear(year: number) {
   }
 
   return weeks;
+}
+
+export function formatWeek(week: string): string {
+    if (weeks.length === 0) weeks = getWeeksOfYear(week.split('-')[1] ? parseInt(week.split('-')[1], 10) : new Date().getFullYear());
+  
+    const currentWeek = weeks.find(w => w.week === week);
+  return formatWeekRange(currentWeek?.dateStart || '', currentWeek?.dateEnd || '');
 }
 
 export function getNextWeek(week:string): WeekDto | undefined {

--- a/src/features/recettes/pages/Recettes.tsx
+++ b/src/features/recettes/pages/Recettes.tsx
@@ -34,7 +34,7 @@ const Recettes: React.FC = () => {
   }, [recettes]);
 
   //ReferenceError: Cannot access 'currentWeek' before initialization
-  const currentWeek = weeks[currentWeekIndex] ?? 'S33-2025';
+  const currentWeek = weeks[currentWeekIndex] ;
 
   useEffect(() => {
     const { start, end } = getMonthDates(currentDate);
@@ -148,18 +148,23 @@ const Recettes: React.FC = () => {
   };
 
   // Consultation et filtrage
-  const filteredRecettes = recettes.filter(recette => {
-    const matchesSearch = 
-      recette.commentRecette?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      recette.amount?.toString().toLowerCase().includes(searchTerm.toLowerCase()) ||
-      recette.dateRecette?.toString().toLowerCase().includes(searchTerm.toLowerCase()) ||
-      recette.referencecar?.toLowerCase().includes(searchTerm.toLowerCase());
+  const filteredRecettes = useMemo(
+    () =>
+      recettes.filter(recette => {
+        const matchesSearch =
+          recette.commentRecette?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          recette.amount?.toString().toLowerCase().includes(searchTerm.toLowerCase()) ||
+          recette.dateRecette?.toString().toLowerCase().includes(searchTerm.toLowerCase()) ||
+          recette.referencecar?.toLowerCase().includes(searchTerm.toLowerCase());
 
-    const matchesWeek = recette.week === 'S33-2025' || recette.week === currentWeek;
-    const matchesCar = selectedCar === '' || recette.referencecar === selectedCar;
+        const weekToFilter = currentWeek || currentWeek;
+        const matchesWeek = weekToFilter === '' || recette.week === weekToFilter;
+        const matchesCar = selectedCar === '' || recette.referencecar === selectedCar;
 
-    return matchesSearch && matchesWeek && matchesCar;
-  });
+        return matchesSearch && matchesWeek && matchesCar;
+      }),
+    [recettes, searchTerm, currentWeek, selectedCar]
+  );
 
   const getStatusBadge = (recette: RecetteDto) => {
     // Logique pour déterminer le statut (exemple basé sur la date)


### PR DESCRIPTION
## Summary
- paginate recettes list by week with previous and next buttons
- replace week dropdown with navigation controls and week-based filtering

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 50 errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a248cad8f88324bafb88ef6e5c6e40